### PR TITLE
Add OpenAI service

### DIFF
--- a/back/controllers/aicourseController.js
+++ b/back/controllers/aicourseController.js
@@ -1,6 +1,7 @@
 // back/controllers/aicourseController.js
 
 const pool = require('../config/db');
+const openai = require('../services/openai');
 
 /**
  * AI 코스 추천 API

--- a/back/package.json
+++ b/back/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-session": "^1.18.1",
+    "axios": "^1.6.7",
     "multer": "^1.4.5-lts.1",
     "passport": "^0.7.0",
     "pg": "^8.13.1"

--- a/back/services/openai.js
+++ b/back/services/openai.js
@@ -1,0 +1,39 @@
+const axios = require('axios');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
+if (!OPENAI_API_KEY) {
+  console.warn('OPENAI_API_KEY is not set');
+}
+
+/**
+ * Send chat messages to OpenAI's chat completion API and return the response text.
+ * @param {Array} messages - Chat messages following OpenAI Chat format
+ * @param {Object} [options] - Additional options for the API call
+ * @returns {Promise<string>} The assistant's reply
+ */
+async function sendChat(messages, options = {}) {
+  const data = {
+    model: 'gpt-3.5-turbo',
+    messages,
+    ...options,
+  };
+  try {
+    const res = await axios.post('https://api.openai.com/v1/chat/completions', data, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+    });
+    const content = res.data.choices[0].message.content;
+    return content.trim();
+  } catch (err) {
+    console.error('OpenAI API error:', err.response ? err.response.data : err.message);
+    throw err;
+  }
+}
+
+module.exports = { sendChat };


### PR DESCRIPTION
## Summary
- add axios based wrapper for OpenAI API
- integrate OpenAI service into `aicourseController`
- declare axios dependency for backend

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846e59b9e2883339da2a077d2c8fa83