### PR TITLE
Add inquiry management feature

### DIFF
--- a/back/controllers/inquiryController.js
+++ b/back/controllers/inquiryController.js
@@ -1,0 +1,109 @@
+const pool = require('../config/db');
+const chatCtrl = require('./chatRoomsController');
+
+const createInquiry = async (req, res) => {
+  const { user_id, title, content } = req.body;
+  if (!user_id || !title || !content) {
+    return res.status(400).json({ error: 'user_id, title and content required' });
+  }
+  try {
+    const { rows } = await pool.query(
+      'INSERT INTO inquiries(user_id, title, content) VALUES($1, $2, $3) RETURNING *',
+      [user_id, title, content]
+    );
+    res.status(201).json({ inquiry: rows[0] });
+  } catch (err) {
+    console.error('createInquiry error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};
+
+const listInquiries = async (_req, res) => {
+  try {
+    const { rows } = await pool.query(
+      `SELECT i.*, u.nickname AS user_nickname
+       FROM inquiries i JOIN users u ON u.id = i.user_id
+       ORDER BY i.created_at DESC`
+    );
+    res.json({ inquiries: rows });
+  } catch (err) {
+    console.error('listInquiries error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};
+
+const getInquiry = async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  try {
+    const { rows } = await pool.query(
+      `SELECT i.*, u.nickname AS user_nickname
+       FROM inquiries i JOIN users u ON u.id = i.user_id
+       WHERE i.id=$1`,
+      [id]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Not found' });
+    res.json({ inquiry: rows[0] });
+  } catch (err) {
+    console.error('getInquiry error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};
+
+const answerInquiry = async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const { answer, answerer_id } = req.body;
+  if (!answer || !answerer_id) {
+    return res.status(400).json({ error: 'answer and answerer_id required' });
+  }
+  try {
+    const { rows } = await pool.query(
+      `UPDATE inquiries
+         SET answer=$1, answerer_id=$2, answered_at=NOW(), status='answered'
+       WHERE id=$3 RETURNING *`,
+      [answer, answerer_id, id]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Not found' });
+    const inquiry = rows[0];
+
+    try {
+      const { rows: roomRows } = await pool.query(
+        `SELECT crm.room_id
+           FROM chat_room_members crm
+          WHERE crm.user_id IN ($1,$2)
+          GROUP BY crm.room_id
+         HAVING COUNT(*) = 2
+            AND (SELECT COUNT(*) FROM chat_room_members WHERE room_id = crm.room_id) = 2
+          LIMIT 1`,
+        [answerer_id, inquiry.user_id]
+      );
+      let roomId;
+      if (roomRows.length) {
+        roomId = roomRows[0].room_id;
+      } else {
+        const roomRes = await pool.query(
+          'INSERT INTO chat_rooms(is_group) VALUES(false) RETURNING id'
+        );
+        roomId = roomRes.rows[0].id;
+        await pool.query(
+          'INSERT INTO chat_room_members(room_id, user_id) VALUES ($1,$2), ($1,$3)',
+          [roomId, answerer_id, inquiry.user_id]
+        );
+      }
+      const mockReq = {
+        params: { roomId },
+        body: { sender_id: answerer_id, type: 'text', content: answer }
+      };
+      const noop = () => ({ json: () => {} });
+      await chatCtrl.postMessage(mockReq, { status: noop, json: () => {} });
+    } catch (e) {
+      console.error('send chat error:', e);
+    }
+
+    res.json({ inquiry });
+  } catch (err) {
+    console.error('answerInquiry error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+};
+
+module.exports = { createInquiry, listInquiries, getInquiry, answerInquiry };

--- a/back/routes/inquiryRoutes.js
+++ b/back/routes/inquiryRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+const verifyAdmin = require('../middleware/verifyAdmin');
+const {
+  createInquiry,
+  listInquiries,
+  getInquiry,
+  answerInquiry,
+} = require('../controllers/inquiryController');
+
+router.post('/inquiries', createInquiry);
+router.get('/admin/inquiries', verifyAdmin, listInquiries);
+router.get('/admin/inquiries/:id', verifyAdmin, getInquiry);
+router.post('/admin/inquiries/:id/answer', verifyAdmin, answerInquiry);
+
+module.exports = router;

--- a/back/server.js
+++ b/back/server.js
@@ -19,6 +19,7 @@ const chatRoutes = require('./routes/chatRoomsRoutes');
 const aicourseRoutes = require('./routes/aicourseRoutes');
 const adminPlaceRoutes = require('./routes/adminPlaceRoutes');
 const placeReportRoutes = require('./routes/placeReportRoutes');
+const inquiryRoutes = require('./routes/inquiryRoutes');
 
 dotenv.config(); // ✅ 환경 변수 로드
 
@@ -66,6 +67,7 @@ app.use('/chat', chatRoutes);
 app.use('/aicourse', aicourseRoutes);
 app.use('/admin', adminPlaceRoutes);
 app.use('/', placeReportRoutes);
+app.use('/', inquiryRoutes);
 
 // ✅ 서버 실행
 const PORT = process.env.PORT || 5000;

--- a/lib/admin_inquiry_detail_page.dart
+++ b/lib/admin_inquiry_detail_page.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'inquiry_service.dart';
+import 'user_provider.dart';
+
+class AdminInquiryDetailPage extends StatefulWidget {
+  final int inquiryId;
+  const AdminInquiryDetailPage({Key? key, required this.inquiryId}) : super(key: key);
+
+  @override
+  State<AdminInquiryDetailPage> createState() => _AdminInquiryDetailPageState();
+}
+
+class _AdminInquiryDetailPageState extends State<AdminInquiryDetailPage> {
+  late Future<Inquiry> _future;
+  final _answerController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _future = InquiryService.fetchInquiry(widget.inquiryId);
+  }
+
+  Future<void> _submit() async {
+    final adminId = Provider.of<UserProvider>(context, listen: false).userId ?? 8;
+    await InquiryService.answerInquiry(widget.inquiryId, adminId, _answerController.text);
+    if (!mounted) return;
+    Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('문의 상세')),
+      body: FutureBuilder<Inquiry>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: Text('조회 실패'));
+          }
+          final inquiry = snapshot.data!;
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(inquiry.title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                Text(inquiry.content),
+                const Divider(),
+                if (inquiry.answer != null)
+                  Text('답변: ${inquiry.answer}')
+                else ...[
+                  TextField(
+                    controller: _answerController,
+                    decoration: const InputDecoration(labelText: '답변 입력'),
+                  ),
+                  const SizedBox(height: 10),
+                  ElevatedButton(onPressed: _submit, child: const Text('답변하기')),
+                ]
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/admin_inquiry_list_page.dart
+++ b/lib/admin_inquiry_list_page.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'inquiry_service.dart';
+import 'admin_inquiry_detail_page.dart';
+
+class AdminInquiryListPage extends StatefulWidget {
+  const AdminInquiryListPage({Key? key}) : super(key: key);
+
+  @override
+  State<AdminInquiryListPage> createState() => _AdminInquiryListPageState();
+}
+
+class _AdminInquiryListPageState extends State<AdminInquiryListPage> {
+  late Future<List<Inquiry>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = InquiryService.fetchInquiries();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('문의 목록')),
+      body: FutureBuilder<List<Inquiry>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('문의가 없습니다.'));
+          }
+          final items = snapshot.data!;
+          return ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final item = items[index];
+              return ListTile(
+                title: Text(item.title),
+                subtitle: Text(item.createdAt),
+                onTap: () async {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) =>
+                          AdminInquiryDetailPage(inquiryId: item.id),
+                    ),
+                  );
+                  setState(() {
+                    _future = InquiryService.fetchInquiries();
+                  });
+                },
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/inquiry_page.dart
+++ b/lib/inquiry_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'user_provider.dart';
+import 'inquiry_service.dart';
+
+class InquiryPage extends StatefulWidget {
+  const InquiryPage({Key? key}) : super(key: key);
+
+  @override
+  State<InquiryPage> createState() => _InquiryPageState();
+}
+
+class _InquiryPageState extends State<InquiryPage> {
+  final _titleController = TextEditingController();
+  final _contentController = TextEditingController();
+
+  Future<void> _submit() async {
+    final userId = Provider.of<UserProvider>(context, listen: false).userId;
+    if (userId == null ||
+        _titleController.text.isEmpty ||
+        _contentController.text.isEmpty) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('제목과 내용을 입력하세요')));
+      return;
+    }
+    await InquiryService.createInquiry(
+        userId, _titleController.text, _contentController.text);
+    if (!mounted) return;
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('문의 하기')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: '제목'),
+            ),
+            const SizedBox(height: 10),
+            TextField(
+              controller: _contentController,
+              decoration: const InputDecoration(labelText: '내용'),
+              maxLines: 5,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(onPressed: _submit, child: const Text('문의 보내기'))
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/inquiry_service.dart
+++ b/lib/inquiry_service.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'constants.dart';
+
+class Inquiry {
+  final int id;
+  final int userId;
+  final String title;
+  final String content;
+  final String createdAt;
+  final String? answer;
+  final String status;
+
+  Inquiry({
+    required this.id,
+    required this.userId,
+    required this.title,
+    required this.content,
+    required this.createdAt,
+    this.answer,
+    required this.status,
+  });
+
+  factory Inquiry.fromJson(Map<String, dynamic> json) {
+    return Inquiry(
+      id: json['id'] as int,
+      userId: json['user_id'] as int,
+      title: json['title'] ?? '',
+      content: json['content'] ?? '',
+      createdAt: json['created_at'] ?? '',
+      answer: json['answer'],
+      status: json['status'] ?? 'pending',
+    );
+  }
+}
+
+class InquiryService {
+  static Future<void> createInquiry(
+      int userId, String title, String content) async {
+    await http.post(
+      Uri.parse('$BASE_URL/inquiries'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'user_id': userId, 'title': title, 'content': content}),
+    );
+  }
+
+  static Future<List<Inquiry>> fetchInquiries() async {
+    final resp = await http.get(
+      Uri.parse('$BASE_URL/admin/inquiries'),
+      headers: {'Content-Type': 'application/json', 'user_id': '8'},
+    );
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      final list = data['inquiries'] as List<dynamic>;
+      return list
+          .map((e) => Inquiry.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception('failed');
+  }
+
+  static Future<Inquiry> fetchInquiry(int id) async {
+    final resp = await http.get(
+      Uri.parse('$BASE_URL/admin/inquiries/$id'),
+      headers: {'Content-Type': 'application/json', 'user_id': '8'},
+    );
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      return Inquiry.fromJson(data['inquiry']);
+    }
+    throw Exception('failed');
+  }
+
+  static Future<void> answerInquiry(
+      int id, int answererId, String answer) async {
+    await http.post(
+      Uri.parse('$BASE_URL/admin/inquiries/$id/answer'),
+      headers: {'Content-Type': 'application/json', 'user_id': '8'},
+      body: jsonEncode({'answer': answer, 'answerer_id': answererId}),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,6 +40,8 @@ import 'adminpage.dart';
 import 'aichatscreen.dart';
 import 'admin_place_requests_page.dart';
 import 'admin_place_reports_page.dart';
+import 'admin_inquiry_list_page.dart';
+import 'inquiry_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -102,6 +104,8 @@ class MyApp extends StatelessWidget {
         '/aichat': (context) => const ChatScreen(),
         '/admin/place-requests': (context) => const AdminPlaceRequestsPage(),
         '/admin/place-reports': (context) => const AdminPlaceReportsPage(),
+        '/admin/inquiries': (context) => const AdminInquiryListPage(),
+        '/inquiry': (context) => const InquiryPage(),
 
         '/CategorySelectionPage': (context) =>
             const CategorySelectionPage(), // Add this line

--- a/lib/my.dart
+++ b/lib/my.dart
@@ -6,6 +6,7 @@ import 'couple.dart';
 import 'place.dart';
 import 'dart:io';
 import 'fri.dart';
+import 'inquiry_page.dart';
 
 class MyPage extends StatefulWidget {
   const MyPage({super.key});
@@ -176,7 +177,18 @@ class _MyPageState extends State<MyPage> {
                     );
                   },
                 ),
-                _buildListTile("문의 하기", Icons.history),
+                _buildListTile(
+                  "문의 하기",
+                  Icons.history,
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => const InquiryPage(),
+                      ),
+                    );
+                  },
+                ),
               ],
             ),
           ),

--- a/localhost.session.sql
+++ b/localhost.session.sql
@@ -7,3 +7,14 @@ CREATE TABLE users (
     birth_date DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+CREATE TABLE inquiries (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    title VARCHAR(255) NOT NULL,
+    content TEXT NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    answer TEXT,
+    answerer_id INTEGER REFERENCES users(id),
+    answered_at TIMESTAMP,
+    status VARCHAR(20) DEFAULT 'pending'
+);


### PR DESCRIPTION
## Summary
- create `inquiries` table
- implement inquiry controller and routes on backend
- register new routes in Express server
- add Flutter pages and service for creating and managing inquiries
- link inquiry pages in main and my pages

## Testing
- `npm test` *(fails: no tests defined)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e0ae86b48333a9cee83e4ad5c590