### PR TITLE
Implement InquiryPage form

### DIFF
--- a/lib/inquiry_page.dart
+++ b/lib/inquiry_page.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'inquiry_service.dart';
+import 'user_provider.dart';
+
+class InquiryPage extends StatefulWidget {
+  const InquiryPage({Key? key}) : super(key: key);
+
+  @override
+  State<InquiryPage> createState() => _InquiryPageState();
+}
+
+class _InquiryPageState extends State<InquiryPage> {
+  final TextEditingController _titleCtrl = TextEditingController();
+  final TextEditingController _contentCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    _contentCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submitInquiry() async {
+    final userId = context.read<UserProvider>().userId;
+    final title = _titleCtrl.text.trim();
+    final content = _contentCtrl.text.trim();
+
+    if (userId == null || title.isEmpty || content.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('제목과 내용을 입력해주세요.')),
+      );
+      return;
+    }
+
+    try {
+      await InquiryService.createInquiry(userId, title, content);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('문의가 등록되었습니다.')),
+      );
+      Navigator.pop(context, true);
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('문의 등록에 실패했습니다.')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('문의하기')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleCtrl,
+              decoration: const InputDecoration(labelText: '제목'),
+            ),
+            const SizedBox(height: 10),
+            TextField(
+              controller: _contentCtrl,
+              decoration: const InputDecoration(labelText: '내용'),
+              maxLines: 5,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _submitInquiry,
+              child: const Text('문의 제출'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add inquiry creation screen
- use `InquiryService.createInquiry` and `UserProvider` for submission
- wire the page via existing routes

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848ec83e5908333aeb89fb835da31f7