### PR TITLE
Add report categories and submit to backend

### DIFF
--- a/back/controllers/placeReportController.js
+++ b/back/controllers/placeReportController.js
@@ -2,16 +2,16 @@ const pool = require('../config/db');
 
 const reportPlace = async (req, res) => {
   const placeId = parseInt(req.params.id, 10);
-  const { user_id, reason } = req.body;
-  if (!user_id || !reason) {
-    return res.status(400).json({ error: 'user_id and reason required' });
+  const { user_id, category, reason } = req.body;
+  if (!user_id || !category || !reason) {
+    return res.status(400).json({ error: 'user_id, category and reason required' });
   }
   try {
     const { rows } = await pool.query(
-      `INSERT INTO place_reports (place_id, user_id, reason, status)
-       VALUES ($1, $2, $3, 'pending')
+      `INSERT INTO place_reports (place_id, user_id, category, reason, status)
+       VALUES ($1, $2, $3, $4, 'pending')
        RETURNING *`,
-      [placeId, user_id, reason]
+      [placeId, user_id, category, reason]
     );
     res.status(201).json({ report: rows[0] });
   } catch (err) {

--- a/lib/admin_place_reports_page.dart
+++ b/lib/admin_place_reports_page.dart
@@ -83,7 +83,8 @@ class _AdminPlaceReportsPageState extends State<AdminPlaceReportsPage> {
               final item = items[index] as Map<String, dynamic>;
               return ListTile(
                 title: Text(item['place_name'] ?? ''),
-                subtitle: Text(item['reason'] ?? ''),
+                subtitle: Text(
+                    '${item['category'] ?? ''} - ${item['reason'] ?? ''}'),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [


### PR DESCRIPTION
## Summary
- allow selecting report category in food place page
- send selected category and reason when submitting a report
- display report category in admin list
- update backend controller to store category

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_684a8cdeff288333a24ac9d2ed4b323d