### PR TITLE
Add category support for place reports

### DIFF
--- a/back/controllers/placeReportController.js
+++ b/back/controllers/placeReportController.js
@@ -3,8 +3,10 @@ const pool = require('../config/db');
 const reportPlace = async (req, res) => {
   const placeId = parseInt(req.params.id, 10);
   const { user_id, category, reason } = req.body;
-  if (!user_id || !category || !reason) {
-    return res.status(400).json({ error: 'user_id, category and reason required' });
+  if (!user_id || !category || !reason || String(category).trim() === '') {
+    return res
+      .status(400)
+      .json({ error: 'user_id, category and reason required' });
   }
   try {
     const { rows } = await pool.query(
@@ -23,7 +25,16 @@ const reportPlace = async (req, res) => {
 const listReports = async (_req, res) => {
   try {
     const { rows } = await pool.query(`
-      SELECT pr.*, u.nickname AS reporter_nickname, p.place_name
+      SELECT
+        pr.id,
+        pr.place_id,
+        pr.user_id,
+        pr.category,
+        pr.reason,
+        pr.status,
+        pr.created_at,
+        u.nickname AS reporter_nickname,
+        p.place_name
       FROM place_reports pr
       JOIN users u ON u.id = pr.user_id
       JOIN place_info p ON p.id = pr.place_id

--- a/lib/admin_place_reports_page.dart
+++ b/lib/admin_place_reports_page.dart
@@ -84,7 +84,7 @@ class _AdminPlaceReportsPageState extends State<AdminPlaceReportsPage> {
               return ListTile(
                 title: Text(item['place_name'] ?? ''),
                 subtitle: Text(
-                    '${item['category'] ?? ''} - ${item['reason'] ?? ''}'),
+                    '카테고리: ${item['category'] ?? ''}\n${item['reason'] ?? ''}'),
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [

--- a/localhost.session.sql
+++ b/localhost.session.sql
@@ -7,3 +7,14 @@ CREATE TABLE users (
     birth_date DATE,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Table for user submitted reports about places
+CREATE TABLE place_reports (
+    id SERIAL PRIMARY KEY,
+    place_id INTEGER NOT NULL REFERENCES place_info(id),
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    category VARCHAR(50) NOT NULL,
+    reason TEXT NOT NULL,
+    status VARCHAR(20) DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
## Summary
- update DB schema: add `category` column for `place_reports`
- validate and insert `category` in controller
- explicitly select `category` when listing reports
- show category in admin reports page

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8ef61fa483338986fffd755c2cba