### PR TITLE
Add admin place edit and report resolution

### DIFF
--- a/back/routes/adminPlaceRoutes.js
+++ b/back/routes/adminPlaceRoutes.js
@@ -2,9 +2,12 @@ const express = require('express');
 const router = express.Router();
 const verifyAdmin = require('../middleware/verifyAdmin');
 const { getPlaceRequests, approvePlaceRequest, rejectPlaceRequest } = require('../controllers/adminPlaceController');
+const { updatePlace, getPlaceByIdAdmin } = require('../controllers/placeController');
 
 router.get('/place-requests', verifyAdmin, getPlaceRequests);
 router.post('/place-requests/:id/approve', verifyAdmin, approvePlaceRequest);
 router.post('/place-requests/:id/reject', verifyAdmin, rejectPlaceRequest);
+router.get('/places/:id', verifyAdmin, getPlaceByIdAdmin);
+router.patch('/places/:id', verifyAdmin, updatePlace);
 
 module.exports = router;

--- a/lib/admin_edit_place_page.dart
+++ b/lib/admin_edit_place_page.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import 'package:provider/provider.dart';
+import 'constants.dart';
+import 'user_provider.dart';
+
+class AdminEditPlacePage extends StatefulWidget {
+  final int placeId;
+  final int reportId;
+  const AdminEditPlacePage({Key? key, required this.placeId, required this.reportId}) : super(key: key);
+
+  @override
+  State<AdminEditPlacePage> createState() => _AdminEditPlacePageState();
+}
+
+class _AdminEditPlacePageState extends State<AdminEditPlacePage> {
+  final TextEditingController nameCtrl = TextEditingController();
+  final TextEditingController addressCtrl = TextEditingController();
+  final TextEditingController phoneCtrl = TextEditingController();
+  final TextEditingController descCtrl = TextEditingController();
+  final TextEditingController priceCtrl = TextEditingController();
+  final TextEditingController mainCatCtrl = TextEditingController();
+  final TextEditingController subCatCtrl = TextEditingController();
+  final TextEditingController imagesCtrl = TextEditingController();
+  final TextEditingController hashtagsCtrl = TextEditingController();
+
+  int? _adminId;
+
+  @override
+  void initState() {
+    super.initState();
+    _adminId = Provider.of<UserProvider>(context, listen: false).userId ?? 8;
+    _load();
+  }
+
+  Future<void> _load() async {
+    final uri = Uri.parse('$BASE_URL/admin/places/${widget.placeId}');
+    final resp = await http.get(uri, headers: {
+      'Content-Type': 'application/json',
+      'user_id': '${_adminId}'
+    });
+    if (resp.statusCode == 200) {
+      final data = jsonDecode(resp.body) as Map<String, dynamic>;
+      setState(() {
+        nameCtrl.text = data['place_name'] ?? '';
+        addressCtrl.text = data['address'] ?? '';
+        phoneCtrl.text = data['phone'] ?? '';
+        descCtrl.text = data['description'] ?? '';
+        priceCtrl.text = jsonEncode(data['price_info'] ?? []);
+        mainCatCtrl.text = data['main_category'] ?? '';
+        subCatCtrl.text = data['sub_category'] ?? '';
+        imagesCtrl.text = (data['images'] as List<dynamic>? ?? []).join(',');
+        hashtagsCtrl.text = (data['hashtags'] as List<dynamic>? ?? []).join(',');
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    final uri = Uri.parse('$BASE_URL/admin/places/${widget.placeId}');
+    await http.patch(uri,
+        headers: {'Content-Type': 'application/json', 'user_id': '${_adminId}'},
+        body: jsonEncode({
+          'place_name': nameCtrl.text,
+          'address': addressCtrl.text,
+          'phone': phoneCtrl.text,
+          'description': descCtrl.text,
+          'price_info': priceCtrl.text.isNotEmpty ? jsonDecode(priceCtrl.text) : null,
+          'main_category': mainCatCtrl.text,
+          'sub_category': subCatCtrl.text,
+          'images': imagesCtrl.text.isNotEmpty ? imagesCtrl.text.split(',') : null,
+          'hashtags': hashtagsCtrl.text.isNotEmpty ? hashtagsCtrl.text.split(',') : null,
+        }));
+
+    final uri2 = Uri.parse('$BASE_URL/admin/place-reports/${widget.reportId}');
+    await http.patch(uri2,
+        headers: {'Content-Type': 'application/json', 'user_id': '${_adminId}'},
+        body: jsonEncode({'message': '문의 내용이 수정되었습니다.'}));
+    if (!mounted) return;
+    Navigator.pop(context, true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('장소 정보 수정')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(controller: nameCtrl, decoration: const InputDecoration(labelText: '이름')),
+            TextField(controller: addressCtrl, decoration: const InputDecoration(labelText: '주소')),
+            TextField(controller: phoneCtrl, decoration: const InputDecoration(labelText: '전화')),
+            TextField(controller: descCtrl, decoration: const InputDecoration(labelText: '설명')),
+            TextField(controller: priceCtrl, decoration: const InputDecoration(labelText: '가격정보(JSON)')),
+            TextField(controller: mainCatCtrl, decoration: const InputDecoration(labelText: '메인 카테고리')),
+            TextField(controller: subCatCtrl, decoration: const InputDecoration(labelText: '서브 카테고리')),
+            TextField(controller: imagesCtrl, decoration: const InputDecoration(labelText: '이미지들(,로 구분)')),
+            TextField(controller: hashtagsCtrl, decoration: const InputDecoration(labelText: '해시태그(,로 구분)')),
+            const SizedBox(height: 20),
+            ElevatedButton(onPressed: _save, child: const Text('저장')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/admin_place_reports_page.dart
+++ b/lib/admin_place_reports_page.dart
@@ -42,14 +42,24 @@ class _AdminPlaceReportsPageState extends State<AdminPlaceReportsPage> {
     throw Exception('failed');
   }
 
-  Future<void> _update(int id, {bool deletePlace = false}) async {
+  Future<void> _update(int id, String msg, {bool deletePlace = false}) async {
     final uri = Uri.parse('$BASE_URL/admin/place-reports/$id');
     await http.patch(uri,
         headers: {'Content-Type': 'application/json', 'user_id': '${_adminId}'},
-        body: jsonEncode({'status': 'resolved', 'delete_place': deletePlace}));
+        body: jsonEncode({'delete_place': deletePlace, 'message': msg}));
     setState(() {
       _future = _loadReports();
     });
+  }
+
+  Future<void> _edit(PlaceReport report) async {
+    final result = await Navigator.pushNamed(context, '/admin/edit-place',
+        arguments: {'placeId': report.placeId, 'reportId': report.id});
+    if (result == true) {
+      setState(() {
+        _future = _loadReports();
+      });
+    }
   }
 
   Future<void> _startChat(int userId, String nickname) async {
@@ -98,14 +108,16 @@ class _AdminPlaceReportsPageState extends State<AdminPlaceReportsPage> {
                     ),
                     IconButton(
                       icon: const Icon(Icons.check),
-                      onPressed: () => _update(item.id),
+                      onPressed: () =>
+                          _update(item.id, '장소 정보에 문제가 없습니다.'),
                     ),
                     IconButton(
                       icon: const Icon(Icons.delete),
-                      onPressed: () => _update(item.id, deletePlace: true),
+                      onPressed: () => _update(item.id, '장소 정보에 문제가 없습니다.', deletePlace: true),
                     ),
                   ],
                 ),
+                onTap: () => _edit(item),
               );
             },
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,6 +41,7 @@ import 'aichatscreen.dart';
 import 'admin_place_requests_page.dart';
 import 'admin_place_reports_page.dart';
 import 'admin_inquiry_list_page.dart';
+import 'admin_edit_place_page.dart';
 import 'inquiry_page.dart';
 import 'course_detail_loader.dart';
 
@@ -105,6 +106,13 @@ class MyApp extends StatelessWidget {
         '/aichat': (context) => const ChatScreen(),
         '/admin/place-requests': (context) => const AdminPlaceRequestsPage(),
         '/admin/place-reports': (context) => const AdminPlaceReportsPage(),
+        '/admin/edit-place': (context) {
+          final args = ModalRoute.of(context)!.settings.arguments as Map<String, dynamic>;
+          return AdminEditPlacePage(
+            placeId: args['placeId'] as int,
+            reportId: args['reportId'] as int,
+          );
+        },
         '/admin/inquiries': (context) => const AdminInquiryListPage(),
         '/inquiry': (context) => const InquiryPage(),
         '/CategorySelectionPage': (context) =>


### PR DESCRIPTION
## Summary
- allow admins to update place information
- expose `/admin/places/:id` GET and PATCH routes
- resolve place reports with chat notification
- add admin UI page for editing places
- open edit page from place reports list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684a977ab9648333bc2ef4e5757c5372